### PR TITLE
Fix namespace conflicts

### DIFF
--- a/labler.gs
+++ b/labler.gs
@@ -1,351 +1,359 @@
-var BASE_LABEL, CACHE, CACHE_VERSION, Label, MY_TEAMS, MY_TEAMS_REGEX, Message, QUERY, Thread, labler,
-  __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+function labler() {
+  var BASE_LABEL, CACHE, CACHE_VERSION, Label, MY_TEAMS, MY_TEAMS_REGEX, Message, QUERY, Thread,
+    __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
-MY_TEAMS = [];
+  MY_TEAMS = [];
 
-BASE_LABEL = ["GitHub"];
+  BASE_LABEL = ["GitHub"];
 
-QUERY = "in:inbox AND ( from:\"notifications@github.com\" OR from:\"noreply@github.com\" )";
+  QUERY = "in:inbox AND ( from:\"notifications@github.com\" OR from:\"noreply@github.com\" )";
 
-MY_TEAMS_REGEX = new RegExp("(" + (MY_TEAMS.join('|')) + ")");
+  MY_TEAMS_REGEX = new RegExp("(" + (MY_TEAMS.join('|')) + ")");
 
-CACHE = CacheService.getPrivateCache();
+  CACHE = CacheService.getPrivateCache();
 
-CACHE_VERSION = 1;
+  CACHE_VERSION = 1;
 
-Label = (function() {
-  Label.all = {};
+  Label = (function() {
+    Label.all = {};
 
-  Label.names = [];
+    Label.names = [];
 
-  Label.loadPersisted = function() {
-    var l, _i, _len, _ref, _results;
-    _ref = GmailApp.getUserLabels();
-    _results = [];
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      l = _ref[_i];
-      _results.push(new Label(l.getName(), l));
-    }
-    return _results;
-  };
-
-  Label.findOrCreate = function(name_parts) {
-    var name;
-    if (name_parts.length > 1) {
-      this.findOrCreate(name_parts.slice(0, name_parts.length - 1));
-    }
-    name = name_parts.join("/");
-    return this.find(name) || new Label(name);
-  };
-
-  Label.find = function(name) {
-    if (__indexOf.call(this.names, name) >= 0) {
-      return this.all[name];
-    }
-  };
-
-  Label.applyAll = function() {
-    var n, _i, _len, _ref, _results;
-    _ref = this.names;
-    _results = [];
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      n = _ref[_i];
-      _results.push(this.all[n].apply());
-    }
-    return _results;
-  };
-
-  function Label(name, _label) {
-    this.name = name;
-    this._label = _label;
-    this._queue = [];
-    this._label || (this._label = GmailApp.createLabel(this.name));
-    Label.all[this.name] = this;
-    Label.names.push(this.name);
-  }
-
-  Label.prototype.queue = function(thread) {
-    if (__indexOf.call(this._queue, thread) < 0) {
-      return this._queue.push(thread);
-    }
-  };
-
-  Label.prototype.apply = function() {
-    var t, threads;
-    threads = (function() {
-      var _i, _len, _ref, _results;
-      _ref = this._queue;
+    Label.loadPersisted = function() {
+      var l, _i, _len, _ref, _results;
+      _ref = GmailApp.getUserLabels();
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        t = _ref[_i];
-        _results.push(t._thread);
+        l = _ref[_i];
+        _results.push(new Label(l.getName(), l));
       }
       return _results;
-    }).call(this);
-    if (threads.length) {
-      this._label.addToThreads(threads);
-    }
-    return this._queue = [];
-  };
+    };
 
-  return Label;
-
-})();
-
-Thread = (function() {
-  Thread.all = {};
-
-  Thread.ids = [];
-
-  Thread.done = [];
-
-  Thread.doneKey = "octogas:v" + CACHE_VERSION + ":threads_done";
-
-  Thread.loadFromSearch = function(query) {
-    var t, threads, _i, _len, _results;
-    threads = GmailApp.search(query);
-    GmailApp.getMessagesForThreads(threads);
-    _results = [];
-    for (_i = 0, _len = threads.length; _i < _len; _i++) {
-      t = threads[_i];
-      _results.push(new Thread(t));
-    }
-    return _results;
-  };
-
-  Thread.labelAllForReason = function() {
-    var id, _i, _len, _ref, _results;
-    _ref = this.ids;
-    _results = [];
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      id = _ref[_i];
-      if (!this.all[id].alreadyDone()) {
-        _results.push(this.all[id].labelForReason());
+    Label.findOrCreate = function(name_parts) {
+      var name;
+      if (name_parts.length > 1) {
+        this.findOrCreate(name_parts.slice(0, name_parts.length - 1));
       }
-    }
-    return _results;
-  };
+      name = name_parts.join("/");
+      return this.find(name) || new Label(name);
+    };
 
-  Thread.loadDoneFromCache = function() {
-    var cached;
-    cached = CACHE.get(this.doneKey);
-    if (cached) {
-      return this.done = JSON.parse(cached);
-    }
-  };
+    Label.find = function(name) {
+      if (__indexOf.call(this.names, name) >= 0) {
+        return this.all[name];
+      }
+    };
 
-  Thread.dumpDoneToCache = function() {
-    return CACHE.put(this.doneKey, JSON.stringify(this.ids));
-  };
-
-  function Thread(_thread) {
-    var m;
-    this._thread = _thread;
-    this.id = this._thread.getId();
-    Thread.all[this.id] = this;
-    Thread.ids.push(this.id);
-    this.messages = (function() {
-      var _i, _len, _ref, _results;
-      _ref = this._thread.getMessages() || [];
+    Label.applyAll = function() {
+      var n, _i, _len, _ref, _results;
+      _ref = this.names;
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        m = _ref[_i];
-        _results.push(new Message(m));
+        n = _ref[_i];
+        _results.push(this.all[n].apply());
       }
       return _results;
-    }).call(this);
-  }
+    };
 
-  Thread.prototype.labelForReason = function() {
-    var reason;
-    reason = this.reason();
-    if (reason.author) {
-      return this.queueLabel(["Author"]);
-    } else if (reason.mention) {
-      return this.queueLabel(["Direct Mention"]);
-    } else if (reason.team_mention === true) {
-      return this.queueLabel(["Team Mention"]);
-    } else if (reason.team_mention) {
-      return this.queueLabel(["Team Mention", reason.team_mention]);
-    } else if (reason.meta) {
-      return this.queueLabel(["Meta"]);
-    } else if (reason.watching === true) {
-      return this.queueLabel(["Watching"]);
-    } else if (reason.watching) {
-      return this.queueLabel(["Watching", reason.watching]);
-    } else {
-      return this.queueLabel(["Unknown"]);
+    function Label(name, _label) {
+      this.name = name;
+      this._label = _label;
+      this._queue = [];
+      this._label || (this._label = GmailApp.createLabel(this.name));
+      Label.all[this.name] = this;
+      Label.names.push(this.name);
     }
-  };
 
-  Thread.prototype.queueLabel = function(name_parts) {
-    var label;
-    name_parts = BASE_LABEL.concat(name_parts);
-    label = Label.findOrCreate(name_parts);
-    return label.queue(this);
-  };
-
-  Thread.prototype.reason = function() {
-    var i;
-    if (!((this._reason != null) || this.messages.length === 0)) {
-      i = this.messages.length - 1;
-      this._reason = this.messages[i].reason();
-      while (this._reason.team_mention === true && i >= 0) {
-        this._reason = this.messages[i].reason();
-        i--;
+    Label.prototype.queue = function(thread) {
+      if (__indexOf.call(this._queue, thread) < 0) {
+        return this._queue.push(thread);
       }
-    }
-    return this._reason;
-  };
+    };
 
-  Thread.prototype.alreadyDone = function() {
-    return Thread.done.indexOf(this.id) >= 0;
-  };
-
-  return Thread;
-
-})();
-
-Message = (function() {
-  Message.all = {};
-
-  Message.keys = [];
-
-  Message.loadReasonsFromCache = function() {
-    var k, reasons, _i, _len, _ref, _results;
-    reasons = CACHE.getAll(this.keys);
-    _ref = this.keys;
-    _results = [];
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      k = _ref[_i];
-      _results.push(this.all[k].loadReason(reasons[k]));
-    }
-    return _results;
-  };
-
-  Message.dumpReasonsToCache = function() {
-    var k, reasons, _i, _len, _ref;
-    reasons = {};
-    _ref = this.keys;
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      k = _ref[_i];
-      reasons[k] = this.all[k].dumpReason();
-    }
-    return CACHE.putAll(reasons);
-  };
-
-  function Message(_message) {
-    this._message = _message;
-    this.id = this._message.getId();
-    this.key = "octogas:v" + CACHE_VERSION + ":message_reason:" + this.id;
-    Message.all[this.key] = this;
-    Message.keys.push(this.key);
-  }
-
-  Message.prototype.reason = function() {
-    return this._reason || (this._reason = (function() {
-      switch (this.headers()['X-GitHub-Reason']) {
-        case 'mention':
-          return {
-            mention: true
-          };
-        case 'team_mention':
-          return {
-            team_mention: this.teamMention() || true
-          };
-        case 'author':
-          return {
-            author: true
-          };
-        default:
-          switch (this.from()) {
-            case "notifications@github.com":
-              return {
-                watching: this.firstNameInHeader('List-ID') || true
-              };
-            case "noreply@github.com":
-              return {
-                meta: true
-              };
-            default:
-              return {};
-          }
+    Label.prototype.apply = function() {
+      var t, threads;
+      threads = (function() {
+        var _i, _len, _ref, _results;
+        _ref = this._queue;
+        _results = [];
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          t = _ref[_i];
+          _results.push(t._thread);
+        }
+        return _results;
+      }).call(this);
+      if (threads.length) {
+        this._label.addToThreads(threads);
       }
-    }).call(this));
-  };
+      return this._queue = [];
+    };
 
-  Message.prototype.loadReason = function(reason) {
-    if (reason != null) {
-      return this._reason = JSON.parse(reason);
-    }
-  };
+    return Label;
 
-  Message.prototype.dumpReason = function() {
-    return JSON.stringify(this.reason());
-  };
+  })();
 
-  Message.prototype.teamMention = function() {
-    var match, message;
-    return this._teamMention || (this._teamMention = (message = this._message.getPlainBody()) ? (match = message.match(MY_TEAMS_REGEX)) ? match[1] : void 0 : void 0);
-  };
+  Thread = (function() {
+    Thread.all = {};
 
-  Message.prototype.from = function() {
-    return this._from || (this._from = this.firstAddressInHeader('From'));
-  };
+    Thread.ids = [];
 
-  Message.prototype.firstAddressInHeader = function(header) {
-    return (this.headers()[header].match(/.*? <(.*)>/) || [])[1];
-  };
+    Thread.done = [];
 
-  Message.prototype.firstNameInHeader = function(header) {
-    return (this.headers()[header].match(/(.*?) <.*>/) || [])[1];
-  };
+    Thread.doneKey = "octogas:v" + CACHE_VERSION + ":threads_done";
 
-  Message.prototype.headers = function() {
-    var key, line, match, parts, value, _i, _len, _ref, _ref1;
-    if (this._headers == null) {
-      this._headers = {};
-      parts = this._message.getRawContent().split("\r\n\r\n", 2);
-      _ref = parts[0].split("\r\n");
+    Thread.loadFromSearch = function(query) {
+      var t, threads, _i, _len, _results;
+      threads = GmailApp.search(query);
+      GmailApp.getMessagesForThreads(threads);
+      _results = [];
+      for (_i = 0, _len = threads.length; _i < _len; _i++) {
+        t = threads[_i];
+        _results.push(new Thread(t));
+      }
+      return _results;
+    };
+
+    Thread.labelAllForReason = function() {
+      var id, _i, _len, _ref, _results;
+      _ref = this.ids;
+      _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        line = _ref[_i];
-        if (match = line.match(/^\s+(.*)/)) {
-          value += " " + match[1];
-        } else {
-          if ((typeof key !== "undefined" && key !== null) && (typeof value !== "undefined" && value !== null)) {
-            this.setHeader(this._headers, key, value);
-          }
-          _ref1 = line.split(": ", 2), key = _ref1[0], value = _ref1[1];
+        id = _ref[_i];
+        if (!this.all[id].alreadyDone()) {
+          _results.push(this.all[id].labelForReason());
         }
       }
-      if ((key != null) && (value != null)) {
-        this.setHeader(this._headers, key, value);
+      return _results;
+    };
+
+    Thread.loadDoneFromCache = function() {
+      var cached;
+      cached = CACHE.get(this.doneKey);
+      if (cached) {
+        return this.done = JSON.parse(cached);
       }
+    };
+
+    Thread.dumpDoneToCache = function() {
+      return CACHE.put(this.doneKey, JSON.stringify(this.ids));
+    };
+
+    function Thread(_thread) {
+      var m;
+      this._thread = _thread;
+      this.id = this._thread.getId();
+      Thread.all[this.id] = this;
+      Thread.ids.push(this.id);
+      this.messages = (function() {
+        var _i, _len, _ref, _results;
+        _ref = this._thread.getMessages() || [];
+        _results = [];
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          m = _ref[_i];
+          _results.push(new Message(m));
+        }
+        return _results;
+      }).call(this);
     }
-    return this._headers;
-  };
 
-  Message.prototype.setHeader = function(headers, key, value) {
-    if (Array.isArray(headers[key])) {
-      return headers[key].push(value);
-    } else if (headers[key] != null) {
-      return headers[key] = [headers[key], value];
-    } else {
-      return headers[key] = value;
+    Thread.prototype.labelForReason = function() {
+      var reason;
+      reason = this.reason();
+      if (reason.author) {
+        return this.queueLabel(["Author"]);
+      } else if (reason.mention) {
+        return this.queueLabel(["Direct Mention"]);
+      } else if (reason.team_mention === true) {
+        return this.queueLabel(["Team Mention"]);
+      } else if (reason.team_mention) {
+        return this.queueLabel(["Team Mention", reason.team_mention]);
+      } else if (reason.meta) {
+        return this.queueLabel(["Meta"]);
+      } else if (reason.watching === true) {
+        return this.queueLabel(["Watching"]);
+      } else if (reason.watching) {
+        return this.queueLabel(["Watching", reason.watching]);
+      } else {
+        return this.queueLabel(["Unknown"]);
+      }
+    };
+
+    Thread.prototype.queueLabel = function(name_parts) {
+      var label;
+      name_parts = BASE_LABEL.concat(name_parts);
+      label = Label.findOrCreate(name_parts);
+      return label.queue(this);
+    };
+
+    Thread.prototype.reason = function() {
+      var i;
+      if (!((this._reason != null) || this.messages.length === 0)) {
+        i = this.messages.length - 1;
+        this._reason = this.messages[i].reason();
+        while (this._reason.team_mention === true && i >= 0) {
+          this._reason = this.messages[i].reason();
+          i--;
+        }
+      }
+      return this._reason;
+    };
+
+    Thread.prototype.alreadyDone = function() {
+      return Thread.done.indexOf(this.id) >= 0;
+    };
+
+    return Thread;
+
+  })();
+
+  Message = (function() {
+    Message.all = {};
+
+    Message.keys = [];
+
+    Message.loadReasonsFromCache = function() {
+      var k, reasons, _i, _len, _ref, _results;
+      reasons = CACHE.getAll(this.keys);
+      _ref = this.keys;
+      _results = [];
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        k = _ref[_i];
+        _results.push(this.all[k].loadReason(reasons[k]));
+      }
+      return _results;
+    };
+
+    Message.dumpReasonsToCache = function() {
+      var k, reasons, _i, _len, _ref;
+      reasons = {};
+      _ref = this.keys;
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        k = _ref[_i];
+        reasons[k] = this.all[k].dumpReason();
+      }
+      return CACHE.putAll(reasons);
+    };
+
+    function Message(_message) {
+      this._message = _message;
+      this.id = this._message.getId();
+      this.key = "octogas:v" + CACHE_VERSION + ":message_reason:" + this.id;
+      Message.all[this.key] = this;
+      Message.keys.push(this.key);
     }
-  };
 
-  return Message;
+    Message.prototype.reason = function() {
+      return this._reason || (this._reason = (function() {
+        switch (this.headers()['X-GitHub-Reason']) {
+          case 'mention':
+            return {
+              mention: true
+            };
+          case 'team_mention':
+            return {
+              team_mention: this.teamMention() || true
+            };
+          case 'author':
+            return {
+              author: true
+            };
+          default:
+            switch (this.from()) {
+              case "notifications@github.com":
+                return {
+                  watching: this.firstNameInHeader('List-ID') || true
+                };
+              case "noreply@github.com":
+                return {
+                  meta: true
+                };
+              default:
+                return {};
+            }
+        }
+      }).call(this));
+    };
 
-})();
+    Message.prototype.loadReason = function(reason) {
+      if (reason != null) {
+        return this._reason = JSON.parse(reason);
+      }
+    };
 
-function labler() {
+    Message.prototype.dumpReason = function() {
+      return JSON.stringify(this.reason());
+    };
+
+    Message.prototype.teamMention = function() {
+      var match, message;
+      return this._teamMention || (this._teamMention = (message = this._message.getPlainBody()) ? (match = message.match(MY_TEAMS_REGEX)) ? match[1] : void 0 : void 0);
+    };
+
+    Message.prototype.from = function() {
+      return this._from || (this._from = this.firstAddressInHeader('From'));
+    };
+
+    Message.prototype.firstAddressInHeader = function(header) {
+      return (this.headers()[header].match(/.*? <(.*)>/) || [])[1];
+    };
+
+    Message.prototype.firstNameInHeader = function(header) {
+      return (this.headers()[header].match(/(.*?) <.*>/) || [])[1];
+    };
+
+    Message.prototype.headers = function() {
+      var key, line, match, parts, value, _i, _len, _ref, _ref1;
+      if (this._headers == null) {
+        this._headers = {};
+        parts = this._message.getRawContent().split("\r\n\r\n", 2);
+        _ref = parts[0].split("\r\n");
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          line = _ref[_i];
+          if (match = line.match(/^\s+(.*)/)) {
+            value += " " + match[1];
+          } else {
+            if ((typeof key !== "undefined" && key !== null) && (typeof value !== "undefined" && value !== null)) {
+              this.setHeader(this._headers, key, value);
+            }
+            _ref1 = line.split(": ", 2), key = _ref1[0], value = _ref1[1];
+          }
+        }
+        if ((key != null) && (value != null)) {
+          this.setHeader(this._headers, key, value);
+        }
+      }
+      return this._headers;
+    };
+
+    Message.prototype.setHeader = function(headers, key, value) {
+      if (Array.isArray(headers[key])) {
+        return headers[key].push(value);
+      } else if (headers[key] != null) {
+        return headers[key] = [headers[key], value];
+      } else {
+        return headers[key] = value;
+      }
+    };
+
+    return Message;
+
+  })();
+
   Label.loadPersisted();
+
   Thread.loadFromSearch(QUERY);
+
   Thread.loadDoneFromCache();
+
   Message.loadReasonsFromCache();
+
   Thread.labelAllForReason();
+
   Label.applyAll();
+
   Thread.dumpDoneToCache();
-  return Message.dumpReasonsToCache();
-};
+
+  Message.dumpReasonsToCache();
+
+}

--- a/muter.gs
+++ b/muter.gs
@@ -1,158 +1,152 @@
-var FETCH_OPTIONS, Message, QUERY, Thread, UNSUB_HEADER, UNSUB_URL_PREFIX, UNSUB_URL_REGEX, muter;
+function muter() {
+  var FETCH_OPTIONS, Message, QUERY, Thread, UNSUB_HEADER, UNSUB_URL_PREFIX, UNSUB_URL_REGEX, id, _i, _len, _ref;
 
-QUERY = "is:mute AND ( from:\"notifications@github.com\" OR from:\"noreply@github.com\" )";
+  QUERY = "is:mute AND ( from:\"notifications@github.com\" OR from:\"noreply@github.com\" )";
 
-UNSUB_HEADER = "List-Unsubscribe";
+  UNSUB_HEADER = "List-Unsubscribe";
 
-UNSUB_URL_PREFIX = "https://github.com/notifications/unsubscribe";
+  UNSUB_URL_PREFIX = "https://github.com/notifications/unsubscribe";
 
-UNSUB_URL_REGEX = new RegExp("<(" + UNSUB_URL_PREFIX + "/.*?)>");
+  UNSUB_URL_REGEX = new RegExp("<(" + UNSUB_URL_PREFIX + "/.*?)>");
 
-FETCH_OPTIONS = {
-  muteHttpExceptions: true
-};
-
-Thread = (function() {
-  Thread.all = {};
-
-  Thread.ids = [];
-
-  Thread.loadFromSearch = function(query) {
-    var t, threads, _i, _len, _results;
-    threads = GmailApp.search(query);
-    Logger.log("found " + threads.length + " threads");
-    GmailApp.getMessagesForThreads(threads);
-    _results = [];
-    for (_i = 0, _len = threads.length; _i < _len; _i++) {
-      t = threads[_i];
-      _results.push(new Thread(t));
-    }
-    return _results;
+  FETCH_OPTIONS = {
+    muteHttpExceptions: true
   };
 
-  function Thread(_thread) {
-    var m;
-    this._thread = _thread;
-    this.id = this._thread.getId();
-    Thread.all[this.id] = this;
-    Thread.ids.push(this.id);
-    this.messages = (function() {
-      var _i, _len, _ref, _results;
-      _ref = this._thread.getMessages() || [];
+  Thread = (function() {
+    Thread.all = {};
+
+    Thread.ids = [];
+
+    Thread.loadFromSearch = function(query) {
+      var t, threads, _i, _len, _results;
+      threads = GmailApp.search(query);
+      GmailApp.getMessagesForThreads(threads);
       _results = [];
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        m = _ref[_i];
-        _results.push(new Message(m));
+      for (_i = 0, _len = threads.length; _i < _len; _i++) {
+        t = threads[_i];
+        _results.push(new Thread(t));
       }
       return _results;
-    }).call(this);
-    this.subject = this._thread.getFirstMessageSubject();
-  }
+    };
 
-  Thread.prototype.unsubscribeAndUnmute = function() {
-    return !!(this.unsubscribe() && this.unmute());
-  };
-
-  Thread.prototype.unsubscribe = function() {
-    var res, url;
-    if (url = this.unsubUrl()) {
-      Logger.log("usub url for '" + this.subject + "': '" + url + "'");
-      if (res = UrlFetchApp.fetch(url, FETCH_OPTIONS)) {
-        if (res.getResponseCode() === 200) {
-          Logger.log("win");
-          return true;
-        } else {
-          Logger.log("lose");
-          return false;
+    function Thread(_thread) {
+      var m;
+      this._thread = _thread;
+      this.id = this._thread.getId();
+      Thread.all[this.id] = this;
+      Thread.ids.push(this.id);
+      this.messages = (function() {
+        var _i, _len, _ref, _results;
+        _ref = this._thread.getMessages() || [];
+        _results = [];
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          m = _ref[_i];
+          _results.push(new Message(m));
         }
-      }
+        return _results;
+      }).call(this);
+      this.subject = this._thread.getFirstMessageSubject();
     }
-  };
 
-  Thread.prototype.unsubUrl = function() {
-    if (this.messages.length > 0) {
-      return this.messages[0].unsubUrl();
-    }
-  };
+    Thread.prototype.unsubscribeAndUnmute = function() {
+      return !!(this.unsubscribe() && this.unmute());
+    };
 
-  Thread.prototype.unmute = function() {
-    Logger.log("unmuting: " + this.subject);
-    this.moveToArchive();
-    return true;
-  };
-
-  Thread.prototype.moveToArchive = function() {
-    return this._thread.moveToArchive();
-  };
-
-  return Thread;
-
-})();
-
-Message = (function() {
-  function Message(_message) {
-    this._message = _message;
-  }
-
-  Message.prototype.unsubUrl = function() {
-    var match, raw, value, _i, _len, _ref;
-    if (raw = this.headers()[UNSUB_HEADER]) {
-      _ref = raw.split(", ");
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        value = _ref[_i];
-        if (match = value.match(UNSUB_URL_REGEX)) {
-          return match[1];
-        }
-      }
-    }
-  };
-
-  Message.prototype.headers = function() {
-    var key, line, match, parts, value, _i, _len, _ref, _ref1;
-    if (this._headers == null) {
-      this._headers = {};
-      parts = this._message.getRawContent().split("\r\n\r\n", 2);
-      _ref = parts[0].split("\r\n");
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        line = _ref[_i];
-        if (match = line.match(/^\s+(.*)/)) {
-          value += " " + match[1];
-        } else {
-          if ((typeof key !== "undefined" && key !== null) && (typeof value !== "undefined" && value !== null)) {
-            this.setHeader(this._headers, key, value);
+    Thread.prototype.unsubscribe = function() {
+      var res, url;
+      if (url = this.unsubUrl()) {
+        if (res = UrlFetchApp.fetch(url, FETCH_OPTIONS)) {
+          if (res.getResponseCode() === 200) {
+            return true;
+          } else {
+            return false;
           }
-          _ref1 = line.split(": ", 2), key = _ref1[0], value = _ref1[1];
         }
       }
-      if ((key != null) && (value != null)) {
-        this.setHeader(this._headers, key, value);
+    };
+
+    Thread.prototype.unsubUrl = function() {
+      if (this.messages.length > 0) {
+        return this.messages[0].unsubUrl();
       }
+    };
+
+    Thread.prototype.unmute = function() {
+      this.moveToArchive();
+      return true;
+    };
+
+    Thread.prototype.moveToArchive = function() {
+      return this._thread.moveToArchive();
+    };
+
+    return Thread;
+
+  })();
+
+  Message = (function() {
+    function Message(_message) {
+      this._message = _message;
     }
-    return this._headers;
-  };
 
-  Message.prototype.setHeader = function(headers, key, value) {
-    if (Array.isArray(headers[key])) {
-      return headers[key].push(value);
-    } else if (headers[key] != null) {
-      return headers[key] = [headers[key], value];
-    } else {
-      return headers[key] = value;
-    }
-  };
+    Message.prototype.unsubUrl = function() {
+      var match, raw, value, _i, _len, _ref;
+      if (raw = this.headers()[UNSUB_HEADER]) {
+        _ref = raw.split(", ");
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          value = _ref[_i];
+          if (match = value.match(UNSUB_URL_REGEX)) {
+            return match[1];
+          }
+        }
+      }
+    };
 
-  return Message;
+    Message.prototype.headers = function() {
+      var key, line, match, parts, value, _i, _len, _ref, _ref1;
+      if (this._headers == null) {
+        this._headers = {};
+        parts = this._message.getRawContent().split("\r\n\r\n", 2);
+        _ref = parts[0].split("\r\n");
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          line = _ref[_i];
+          if (match = line.match(/^\s+(.*)/)) {
+            value += " " + match[1];
+          } else {
+            if ((typeof key !== "undefined" && key !== null) && (typeof value !== "undefined" && value !== null)) {
+              this.setHeader(this._headers, key, value);
+            }
+            _ref1 = line.split(": ", 2), key = _ref1[0], value = _ref1[1];
+          }
+        }
+        if ((key != null) && (value != null)) {
+          this.setHeader(this._headers, key, value);
+        }
+      }
+      return this._headers;
+    };
 
-})();
+    Message.prototype.setHeader = function(headers, key, value) {
+      if (Array.isArray(headers[key])) {
+        return headers[key].push(value);
+      } else if (headers[key] != null) {
+        return headers[key] = [headers[key], value];
+      } else {
+        return headers[key] = value;
+      }
+    };
 
-function muter() {
-  var id, _i, _len, _ref;
-  Logger.log("starting");
+    return Message;
+
+  })();
+
   Thread.loadFromSearch(QUERY);
+
   _ref = Thread.ids;
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
     id = _ref[_i];
     Thread.all[id].unsubscribeAndUnmute();
   }
-  return Logger.log("done");
-};
+
+}

--- a/script/compile
+++ b/script/compile
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 for file in ./src/*.coffee; do
+  # Compile CoffeeScript and cleanup global wraper to work with GAS
   base=$(basename $file .coffee)
-  coffee --no-header -csb < ./src/${base}.coffee | sed "s/${base} = function/function ${base}/" > ${base}.gs
+  coffee --no-header -cs\
+    < ./src/${base}.coffee\
+    | sed "s/^(function() {/function ${base}() {/"\
+    | sed "s/^}).call(this);/}/" \
+    > ${base}.gs
 done

--- a/src/labler.coffee
+++ b/src/labler.coffee
@@ -325,14 +325,11 @@ class Message
       headers[key] = value
 
 # Find all GitHub notifications in inbox and label them appropriately.
-#
-# Returns nothing.
-labler = ->
-  Label.loadPersisted()
-  Thread.loadFromSearch QUERY
-  Thread.loadDoneFromCache()
-  Message.loadReasonsFromCache()
-  Thread.labelAllForReason()
-  Label.applyAll()
-  Thread.dumpDoneToCache()
-  Message.dumpReasonsToCache()
+Label.loadPersisted()
+Thread.loadFromSearch QUERY
+Thread.loadDoneFromCache()
+Message.loadReasonsFromCache()
+Thread.labelAllForReason()
+Label.applyAll()
+Thread.dumpDoneToCache()
+Message.dumpReasonsToCache()

--- a/src/muter.coffee
+++ b/src/muter.coffee
@@ -30,8 +30,6 @@ class Thread
   @loadFromSearch: (query) ->
     threads = GmailApp.search query
 
-    Logger.log "found #{threads.length} threads"
-
     # Preload all the messages to speed things up.
     GmailApp.getMessagesForThreads threads
     new Thread(t) for t in threads
@@ -60,13 +58,10 @@ class Thread
   # Returns true if the request was successful, false otherwise.
   unsubscribe: ->
     if url = @unsubUrl()
-      Logger.log "usub url for '#{@subject}': '#{url}'"
       if res = UrlFetchApp.fetch url, FETCH_OPTIONS
         if res.getResponseCode() == 200
-          Logger.log "win"
           true
         else
-          Logger.log "lose"
           false
 
   # Extracts the unsubscribe URL from the first message's headers.
@@ -79,7 +74,6 @@ class Thread
   #
   # Returns true.
   unmute: ->
-    Logger.log "unmuting: #{@subject}"
     @moveToArchive()
     true
 
@@ -143,8 +137,6 @@ class Message
     else
       headers[key] = value
 
-muter = ->
-  Logger.log "starting"
-  Thread.loadFromSearch QUERY
-  Thread.all[id].unsubscribeAndUnmute() for id in Thread.ids
-  Logger.log "done"
+# Find all muted GitHub conversations and unsubscribe from them
+Thread.loadFromSearch QUERY
+Thread.all[id].unsubscribeAndUnmute() for id in Thread.ids


### PR DESCRIPTION
I've been getting errors for a few days about class methods not being defined. It was because the namespace is shared between all scripts in a Google Apps Scripts project. The labler and muter scripts both define a `Thread` class, so depending on the load order, the wrong version would exist when the labler/muter functions ran.

This PR adds back the CoffeeScript top-level function wrapper and adds some sed hackery to rewrite it into a named function that Google likes.

@mislav this should fix the problem you were seeing.
