### PR TITLE
handle messages without a From address

### DIFF
--- a/labler.gs
+++ b/labler.gs
@@ -319,7 +319,8 @@ function labler() {
     };
 
     Message.prototype.firstAddressInHeader = function(header) {
-      return (this.headers()[header].match(/.*? <(.*)>/) || [])[1];
+      var _ref, _ref1;
+      return (_ref = this.headers()[header]) != null ? (_ref1 = _ref.match(/.*? <(.*)>/)) != null ? _ref1[1] : void 0 : void 0;
     };
 
     Message.prototype.firstNameInHeader = function(header) {

--- a/src/labler.coffee
+++ b/src/labler.coffee
@@ -280,7 +280,7 @@ class Message
   #
   # Retruns a String or undefined.
   firstAddressInHeader: (header) ->
-    (@headers()[header].match(/.*? <(.*)>/) || [])[1]
+    @headers()[header]?.match(/.*? <(.*)>/)?[1]
 
   # The the name our of an address header like "From: Foo Bar <foobar@gmail.com>"
   #


### PR DESCRIPTION
I'm not sure how an email can have no `From:` header, but I was getting an exception where the regex in `firstAddressInHeader` was returning `undefined`. This should fix that.
