### PR TITLE
Fix muter

### DIFF
--- a/muter.gs
+++ b/muter.gs
@@ -73,8 +73,13 @@ function muter() {
     };
 
     Thread.prototype.unmute = function() {
+      this.moveToInbox();
       this.moveToArchive();
       return true;
+    };
+
+    Thread.prototype.moveToInbox = function() {
+      return this._thread.moveToInbox();
     };
 
     Thread.prototype.moveToArchive = function() {

--- a/src/muter.coffee
+++ b/src/muter.coffee
@@ -70,12 +70,19 @@ class Thread
   unsubUrl: ->
     @messages[0].unsubUrl() if @messages.length > 0
 
-  # Unmutes the thread by moving it to the archive.
+  # Unmutes the thread by moving it to the inbox and then to the archive.
   #
   # Returns true.
   unmute: ->
+    @moveToInbox()
     @moveToArchive()
     true
+
+  # Move the thread to the inbox.
+  #
+  # Returns nothing.
+  moveToInbox: ->
+    @_thread.moveToInbox()
 
   # Move the thread to the archive.
   #


### PR DESCRIPTION
The muter script hasn't been working because the hack of moving the thread to the archive to unmute it no longer works. This PR updates the script to move the thread to the inbox before moving it to the archive, which seems to work.